### PR TITLE
Various small changes: clang, size_t, const, fix UD, verboseness, ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
-CC = gcc
-CFLAGS = -std=c11 -Wall -Wextra -pedantic -Wshadow -D_POSIX_C_SOURCE=200809L
-CPPFLAGS = -MMD -MF $*.d
-LDLIBS = -lreadline
-OBJS = builtins.o execute.o interrupt_handler.o
+CC ?= gcc
+CPPFLAGS=-D_POSIX_C_SOURCE=200809L
+CFLAGS=-std=c11
+ifeq ($(CC), clang)
+	CFLAGS += -Weverything -pedantic -Wno-vla
+else
+	CFLAGS += -Wall -Wextra -pedantic
+endif
+CPPFLAGS += -MMD -MF $*.d
+LDLIBS=-lreadline
+OBJS=zish.o builtins.o execute.o interrupt_handler.o
 
 all: zish
 

--- a/builtins.c
+++ b/builtins.c
@@ -15,28 +15,28 @@
  *
  * @returns status of the command
  */
-static enum status_code zish_cd(int argc, char **argv);
+static enum status_code zish_cd(size_t argc, char *argv[argc]);
 
 /**
  * Builtin: print help
  *
  * @returns status of the command
  */
-static enum status_code zish_help(int argc, char **argv);
+static enum status_code zish_help(size_t argc, char *argv[argc]);
 
 /**
  * Builtin: exit the shell
  *
  * @returns STAT_EXIT
  */
-static enum status_code zish_exit(int argc, char **argv);
+static enum status_code zish_exit(size_t argc, char *argv[argc]);
 
 /**
  * Builtin: assigns a value to a variable
  *
  * @returns status of the command
  */
-static enum status_code zish_assign_variable(int argc, char **argv);
+static enum status_code zish_assign_variable(size_t argc, char *argv[argc]);
 
 char *builtin_str[ZISH_NUM_BUILTINS] = {
     "cd",
@@ -58,7 +58,7 @@ builtin_func_t builtin_func[ZISH_NUM_BUILTINS] = {
 
 struct alias **aliases;
 
-static enum status_code zish_cd(int argc, char **argv)
+static enum status_code zish_cd(size_t argc, char *argv[argc])
 {
     char *dir = NULL;
     if (argc < 2) {
@@ -78,7 +78,7 @@ static enum status_code zish_cd(int argc, char **argv)
     return STAT_SUCCESS;
 }
 
-static enum status_code zish_help(int argc, char **argv)
+static enum status_code zish_help(size_t argc, char *argv[argc])
 {
     (void)argc;
     (void)argv;
@@ -99,7 +99,7 @@ static enum status_code zish_help(int argc, char **argv)
     return STAT_SUCCESS;
 }
 
-static enum status_code zish_exit(int argc, char **argv)
+static enum status_code zish_exit(size_t argc, char *argv[argc])
 {
     (void)argc;
     (void)argv;
@@ -108,7 +108,7 @@ static enum status_code zish_exit(int argc, char **argv)
     return STAT_EXIT;
 }
 
-enum status_code zish_define_alias(int argc, char **argv)
+enum status_code zish_define_alias(size_t argc, char *argv[argc])
 {
     if (argc < 3) {
         fprintf(stderr, "zish: expected 2 arguments to `alias`\n");
@@ -149,7 +149,7 @@ enum status_code zish_define_alias(int argc, char **argv)
     return STAT_SUCCESS;
 }
 
-static enum status_code zish_assign_variable(int argc, char **argv)
+static enum status_code zish_assign_variable(size_t argc, char *argv[argc])
 {
     if (argc < 3) {
         fprintf(stderr, "zish: expected 2 arguments to let\n");
@@ -164,7 +164,7 @@ static enum status_code zish_assign_variable(int argc, char **argv)
     return STAT_SUCCESS;
 }
 
-enum status_code zish_source_file(int argc, char **argv)
+enum status_code zish_source_file(size_t argc, char *argv[argc])
 {
     (void)argc;
     (void)argv;

--- a/builtins.c
+++ b/builtins.c
@@ -1,14 +1,14 @@
 #include "builtins.h"
 
-#include "aliases.h"
-#include "execute.h"
-
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <unistd.h>
+
+#include "aliases.h"
+#include "execute.h"
 
 /**
  * Builtin: change into a directory
@@ -68,7 +68,7 @@ static enum status_code zish_cd(size_t argc, char *argv[argc])
     }
 
     if (chdir(dir) != 0) {
-        perror("zish");
+        perror("zish: chdir()");
         free(dir);
         return STAT_FAILURE;
     }
@@ -127,7 +127,7 @@ enum status_code zish_define_alias(size_t argc, char *argv[argc])
 
     struct alias *new_alias = malloc(sizeof(*new_alias));
     if (!new_alias) {
-        perror("malloc");
+        perror("zish: malloc()");
         return STAT_FAILURE;
     }
 
@@ -136,7 +136,7 @@ enum status_code zish_define_alias(size_t argc, char *argv[argc])
 
     struct alias **new_aliases = realloc(aliases, (i + 2) * sizeof(struct alias));
     if (!aliases) {
-        perror("realloc");
+        perror("zish: realloc()");
         free(new_alias);
         return STAT_FAILURE;
     }
@@ -157,7 +157,7 @@ static enum status_code zish_assign_variable(size_t argc, char *argv[argc])
     }
 
     if (setenv(argv[1], argv[2], true) == -1) {
-        perror("setenv");
+        perror("zish: setenv()");
         return STAT_FAILURE;
     }
 

--- a/builtins.h
+++ b/builtins.h
@@ -51,4 +51,3 @@ extern enum status_code zish_define_alias(size_t argc, char *argv[argc]);
 enum status_code zish_source_file(size_t argc, char **argv);
 
 #endif /* BUILTINS_H */
-

--- a/builtins.h
+++ b/builtins.h
@@ -1,12 +1,14 @@
 #ifndef BUILTINS_H
 #define BUILTINS_H
 
+#include <stdlib.h>
+
 #include "execute.h"
 
 /**
  * Builtin function type
  */
-typedef enum status_code (*builtin_func_t)(int, char**);
+typedef enum status_code (*builtin_func_t)(size_t num_args, char *args[num_args]);
 
 
 /**
@@ -39,14 +41,14 @@ extern struct alias **aliases;
  *
  * @returns status of the command
  */
-extern enum status_code zish_define_alias(int argc, char **argv);
+extern enum status_code zish_define_alias(size_t argc, char *argv[argc]);
 
 /**
  * Builtin: source a file
  *
  * @returns status of the command
  */
-enum status_code zish_source_file(int argc, char **argv);
+enum status_code zish_source_file(size_t argc, char **argv);
 
 #endif /* BUILTINS_H */
 

--- a/execute.c
+++ b/execute.c
@@ -6,6 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <errno.h>
+
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -17,7 +19,7 @@
 *
 * @returns pointer to the char* array
 */
-static char **zish_split_line(char *line, int *num_args);
+static char **zish_split_line(char *line, size_t *num_args);
 
 /**
 * Returns the next token in the line, similar to strtok
@@ -31,14 +33,14 @@ static char *zish_linetok(char *line);
 *
 * @returns pointer to the first occurance of c
 */
-static void *zish_rawmemchr(const void *s, int c);
+static void *zish_rawmemchr(void *s, int c);
 
 /**
 * Execute a given command
 *
 * @returns status of the command
 */
-static enum status_code zish_exec(char **args, int num_args);
+static enum status_code zish_exec(size_t num_args, char *args[num_args]);
 
 /**
 * Launches a binary
@@ -68,10 +70,10 @@ void zish_repl(void)
             add_history(line);
         write_history(history_full_path);
 
-        int num_args;
+        size_t num_args;
         args = zish_split_line(line, &num_args);
 
-        status = zish_exec(args, num_args);
+        status = zish_exec(num_args, args);
 
         free(line);
         free(args);
@@ -79,10 +81,10 @@ void zish_repl(void)
 }
 
 #define ZISH_TOKEN_BUFSIZE 64
-static char **zish_split_line(char *line, int *num_args)
+static char **zish_split_line(char *line, size_t *num_args)
 {
-    int    bufsize = ZISH_TOKEN_BUFSIZE;
-    int    pos     = 0;
+    size_t bufsize = ZISH_TOKEN_BUFSIZE;
+    size_t    pos     = 0;
     char **tokens  = malloc(bufsize * sizeof(*tokens));
     char  *token   = NULL;
 
@@ -142,17 +144,17 @@ static char *zish_linetok(char *line)
     return token;
 }
 
-static void *zish_rawmemchr(const void *s, int c)
+static void *zish_rawmemchr(void *s, int c)
 {
-    const char *str = s;
+    char *str = s;
     while (*str != (char)c) {
         ++str;
     }
 
-    return (void*)str;
+    return str;
 }
 
-static enum status_code zish_exec(char **args, int num_args)
+static enum status_code zish_exec(size_t num_args, char *args[num_args])
 {
     for (size_t i = 0; aliases[i]; ++i) {
         if (strcmp(args[0], aliases[i]->name) == 0) {
@@ -176,20 +178,34 @@ static enum status_code zish_launch(char **args)
     int status;
 
     pid = fork();
+    if (pid < 0) {
+        // Error forking
+        perror("zish: fork()");
+        exit(EXIT_FAILURE);
+    }
+
     if (pid == 0) {
         // Child process
         if (execvp(args[0], args) == -1) {
-            perror("zish");
+            perror("zish: execvp()");
         }
+        /* should not reach:  only returns on error */
         exit(EXIT_FAILURE);
-    } else if (pid < 0) {
-        // Error forking
-        perror("zish");
     } else {
         // Parent process
+        pid_t err;
         do {
-           waitpid(pid, &status, WUNTRACED);
-        } while (!WIFEXITED(status) && !WIFSIGNALED(status));
+           err = waitpid(pid, &status, WUNTRACED);
+           /* if an waitpid() errored but not because of the parent being
+            * interrupted, print it, but continue trying
+            * TODO:  If parent is interrupted, kill child?
+            */
+           if (err != pid && err != EINTR) {
+               perror("zish: waitpid()");
+               continue;
+           }
+        } while (err != pid || /* status is valid */
+                 (!WIFEXITED(status) && !WIFSIGNALED(status)));
     }
 
     if (status) {

--- a/execute.c
+++ b/execute.c
@@ -1,8 +1,5 @@
 #include "execute.h"
 
-#include "aliases.h"
-#include "builtins.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -13,6 +10,9 @@
 
 #include <readline/readline.h>
 #include <readline/history.h>
+
+#include "aliases.h"
+#include "builtins.h"
 
 /**
 * Splits a line into different arguments
@@ -89,7 +89,7 @@ static char **zish_split_line(char *line, size_t *num_args)
     char  *token   = NULL;
 
     if (!tokens) {
-        perror("zish");
+        perror("zish: malloc()");
     }
 
     token = zish_linetok(line);
@@ -103,7 +103,7 @@ static char **zish_split_line(char *line, size_t *num_args)
             tokens   = realloc(tokens, bufsize * sizeof(*tokens));
 
             if (!tokens) {
-                perror("zish");
+                perror("zish: realloc()");
                 exit(EXIT_FAILURE);
             }
         }

--- a/interrupt_handler.c
+++ b/interrupt_handler.c
@@ -28,7 +28,7 @@ static void zish_interrupt_handler(int signo)
 void zish_register_interrupt_handler(void)
 {
     if (signal(SIGINT, &zish_interrupt_handler) == SIG_ERR) {
-        perror("zish");
+        perror("zish: signal()");
         exit(EXIT_FAILURE);
     }
 }

--- a/zish.c
+++ b/zish.c
@@ -58,7 +58,7 @@ static void zish_initialize(void)
         setenv("PS1", "$ ", false);
 
     char *home_path = getenv("HOME");
-    int home_path_size = strlen(home_path);
+    size_t home_path_size = strlen(home_path);
 
     history_full_path = malloc((home_path_size + strlen(history_file) + 2) * sizeof(*history_full_path));
     strcpy(history_full_path, home_path);
@@ -75,7 +75,7 @@ static void zish_initialize(void)
 
     free(config_full_path);
 
-    srand(time(NULL));
+    srand((unsigned int)(time(NULL)));
 
     aliases = calloc(1, sizeof(*aliases));
 }

--- a/zish.c
+++ b/zish.c
@@ -92,7 +92,7 @@ static void zish_cleanup(void)
 
 static void zish_touch(const char *path)
 {
-    FILE *f = fopen(path, "r+");
+    FILE *f = fopen(path, "a");
     if (f == NULL) {
         fprintf(stderr, "zish: fopen(%s): \"%s\"\n", path, strerror(errno));
         exit(EXIT_FAILURE);

--- a/zish.c
+++ b/zish.c
@@ -1,19 +1,16 @@
-#include "builtins.h"
-#include "interrupt_handler.h"
-#include "execute.h"
-
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <errno.h>
 
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-#include <readline/readline.h>
 #include <readline/history.h>
+
+#include "builtins.h"
+#include "interrupt_handler.h"
+#include "execute.h"
+
 
 /**
  * Initializes everything needed
@@ -95,11 +92,11 @@ static void zish_cleanup(void)
 
 static void zish_touch(const char *path)
 {
-    int fd = open(path, O_RDWR | O_CREAT | O_NONBLOCK | O_NOCTTY, 0666);
-    if (fd < 0) {
-        fprintf(stderr, "zish: Can't open history file.\n");
+    FILE *f = fopen(path, "r+");
+    if (f == NULL) {
+        fprintf(stderr, "zish: fopen(%s): \"%s\"\n", path, strerror(errno));
         exit(EXIT_FAILURE);
     }
-    close(fd);
+    fclose(f);
 }
 


### PR DESCRIPTION
**Support clang, use `size_t`, `const`, fix UD in `waitpid()`:**
 - Makefile:  Support clang, add "zish.o" to `OBJS`, add warnings
 - builtins/execute: Use `f(size_t argc, char *argv[argc])` instead of
   `f(int argc, char **argv)` or `f(char **argc, int argc)`
 - execute: `zish_rawmemchr()` was claming it's first parameter as `const` but it
   returned a reference to it as non-`const`, leading to
   `const`-incorrectness since the user could be tempted to modify said
   returned pointer, thinking their original `const` pointer wasn't
   modified though it now is.
 - `waitpid()` does not always give a valid status, handle that.
 - A bit more verbose `perror()` messages

**reorder headers, more verbose errors, `fopen`:**
 - headers: `"file.h"`, `<iso-c>`, `<posix>`, `<libs>`, `"own"`
   This mostly ensures the correct inclusion, especially for
   `feature_test_macros (7)`
 - pass function name to `perror()`
 - use `fopen()` since it also handles `umask`